### PR TITLE
Added support for disabling Serial.begin()

### DIFF
--- a/DebugUtils/DebugUtils.h
+++ b/DebugUtils/DebugUtils.h
@@ -3,9 +3,11 @@
 #if DEBUGLEVEL >= 0
 #define DEBUGPRINT0(x) Serial.print(x)
 #define DEBUGPRINTLN0(x) Serial.println(x)
+#define DEBUGSERIALBEGIN(x) Serial.begin(x)
 #else
 #define DEBUGPRINT0(x)
 #define DEBUGPRINTLN0(x)
+#define DEBUGSERIALBEGIN(x)
 #endif
 
 #if DEBUGLEVEL >= 1


### PR DESCRIPTION
Added support for disabling Serial.begin()

Added:
#define DEBUGSERIALBEGIN(x) Serial.begin(x) / #define DEBUGSERIALBEGIN(x)
To " #if DEBUGLEVEL >= 0 "

So by setting " #define DEBUGLEVEL -1 " at the top of the skatch, Serial.begin(); will not compile into the program.